### PR TITLE
Keyboard Accessibility

### DIFF
--- a/app/src/components/analysis/Breakdown.jsx
+++ b/app/src/components/analysis/Breakdown.jsx
@@ -89,7 +89,7 @@ const Breakdown = ({
 						renderPronunciation(item, language)
 					}
 				</div>
-				<div
+				<button
 				className={`${styles.sentenceItem} ${
 					isWhitespace ? styles.whitespace : ""
 				} ${
@@ -101,9 +101,11 @@ const Breakdown = ({
 				data-role={getCleanedType(item.type)}
 				onMouseEnter={() => handleWordInfoEnter(item)}
 				onClick={() => handleWordClick(item)}
+				// TODO: Translate this aria-label into other supported languages
+				aria-label={`Show details for ${item.text}`}
 				>
 				{item.text}
-				</div>
+				</button>
 				{item.grammar?.particles?.length > 0 && renderParticles(item)}
 			</div>
 			);

--- a/app/src/components/analysis/Breakdown.jsx
+++ b/app/src/components/analysis/Breakdown.jsx
@@ -101,6 +101,11 @@ const Breakdown = ({
 				data-role={getCleanedType(item.type)}
 				onMouseEnter={() => handleWordInfoEnter(item)}
 				onClick={() => handleWordClick(item)}
+				onKeyDown={(e) => {
+					if (e.key === 'Enter') {
+						handleWordClick(item)
+					}
+				}}
 				// TODO: Translate this aria-label into other supported languages
 				aria-label={`Show details for ${item.text}`}
 				>

--- a/app/src/styles/components/sentenceanalyzer/breakdown.module.scss
+++ b/app/src/styles/components/sentenceanalyzer/breakdown.module.scss
@@ -79,6 +79,10 @@
 		font-family:var(--font-kr-serif);
 		font-size:2.6rem;
 
+		// override default button styles
+		background-color: unset;
+		border: unset;
+
 		&::after {
 			position: absolute;
 			content: '';


### PR DESCRIPTION
Hey @JamesAC42, here's that PR for issue #2

- Updated sentence items to use button element
- Added aria-label to sentence items (currently only in English, this will need translation for other languages) 
- Updated sentence item styles to remove default button styling (background, outline)

I wasn't able to test / QA this since I don't have env variables, so I just eyeballed these using browser dev tools. Definitely double-check these changes before merging ;)

You also might want to look into text contrast ratios as another accessibility improvement. Will add details & pics in another issue.

I'm excited to see the project moving along & expanding to other languages btw, exciting stuff! Have you considered starting a Discord server for folks to follow the development and contribute to the codebase? I think there is a lot of potential for community involvement here. Feel free to reach out on Discord (`@themitchell`) if you'd like to chat sometime!